### PR TITLE
Fix/modal info display solution

### DIFF
--- a/app/css/user-panel.scss
+++ b/app/css/user-panel.scss
@@ -1,7 +1,7 @@
 .user-panel {
   display: flex;
   flex-flow: column nowrap;
-  padding: 16px;
+  padding: 24px;
 
   > .header {
     flex: 0 0 48px;

--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -24,7 +24,7 @@ const Gallery = ({ users }: GalleryProps) => {
   const handleModalOpen = (id: number) => {
     const user = usersList.find((item) => item.id === id) || null;
 
-    if(user) {
+    if (user) {
       setSelectedUser(user);
       setIsModalOpen(true);
     }
@@ -99,7 +99,7 @@ const Gallery = ({ users }: GalleryProps) => {
                     <FaPhone className="icon" />
                     <div className="value">{selectedUser.phone}</div>
                   </div>
-                  <div className="fields">
+                  <div className="field">
                     <FaEnvelope className="icon" />
                     <div className="value">{selectedUser.email}</div>
                   </div>

--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-icons/fa6";
 
 import Modal from "./modal";
-
+//
 import { User } from "./types/user";
 
 export type GalleryProps = {


### PR DESCRIPTION
Fixed the email display being stacked in the modal by changing the classname of the div that contains
the icon and the email from "fields" to "field"

from:

```
<div className="field">
  <FaEnvelope className="icon" />
  <div className="value">{selectedUser.email}</div>
</div>
```

to:

```
<div className="field">
  <FaEnvelope className="icon" />
  <div className="value">{selectedUser.email}</div>
</div>
```

Mobile View:

![modal-display-fix](https://github.com/user-attachments/assets/7f91ed47-8382-4924-9914-721543ecc04c)

Desktop View:

![image](https://github.com/user-attachments/assets/70170f6e-75bd-46bc-9e70-2f3eae9c78b6)

